### PR TITLE
Fix Mixed Integer Solver

### DIFF
--- a/src/high-level.lisp
+++ b/src/high-level.lisp
@@ -221,6 +221,16 @@
 	 (setf (foreign-slot-value ctrl '(:struct integer-control-parameters)
 				   'clique-cuts)
 	       (if (member 'clique cut-methods) :on :off))
+	 (if enable-presolver
+	     (setf (foreign-slot-value ctrl '(:struct integer-control-parameters)
+				       'presolve)
+		   :on)
+	     (progn
+	       (%simplex glpk-ptr (null-pointer))
+	       (case (%get-status glpk-ptr)
+		 ((:no-feasible-solution-exists :infeasible)
+		  (error 'lp:infeasible-problem-error))
+		 (:unbounded (error 'lp:unbounded-problem-error)))))
 	 ;; TODO: check if all variables are binary, to enable BINARIZE
 	 ;; TODO: support more options
 	 (%intopt glpk-ptr ctrl)


### PR DESCRIPTION
This fixes  #8, by always preparing the problem with either the simplex solver or the pre-processor, as mentioned in the issue before.

As a side-note: While GLPK by default doesn't enable the pre-processor, I feel like it might make sense to change the default value of `enable-presolver` to non-nil, just because the API interaction is different.