### PR TITLE
Drop trivial-garbage dependency in system specification

### DIFF
--- a/linear-programming-glpk.asd
+++ b/linear-programming-glpk.asd
@@ -10,9 +10,7 @@
   :mailto "NeilLindquist5@gmail.com"
   :source-control (:git "https://github.com/neil-lindquist/linear-programming-gplk.git")
 
-  :depends-on (:cffi
-               :trivial-garbage ;; for finalizer to destroy glpk problem objects
-               :linear-programming)
+  :depends-on (:cffi :linear-programming)
   :serial t
   :pathname "src"
   :components ((:file "package")


### PR DESCRIPTION
Due to 5f7519c34187e92d256698726d97495ee050aaf1, the trivial-garbage dependency shouldn't be necessary anymore.