### PR TITLE
Throw error when no constraints are given

### DIFF
--- a/src/high-level.lisp
+++ b/src/high-level.lisp
@@ -76,6 +76,8 @@
     (%set-obj-dir glpk-ptr (if (eq (lp:problem-type problem) 'lp:max) :max :min))
 
     ;; Set the number of constraints
+    (unless (< 0 (length prob-constraints))
+      (error "No constraints"))
     (%add-rows glpk-ptr (length prob-constraints))
 
     ;; Set the number of variables, their names, and their bounds

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -93,3 +93,8 @@
 			     (< 0 y))
       (error "Should not work"))))
 
+
+(test :no-constraints
+  (fiveam:signals (error)
+    (lp:with-solved-problem ((max x))
+      (error "Should not work"))))


### PR DESCRIPTION
I accidentally triggered a few situations, where linear programmes had no real constraints, and calling `glp_add_rows` with 0 throws an [error and aborts](https://github.com/firedrakeproject/glpk/blob/45156a549252849cad016366022aa1af50990613/src/glpapi01.c#L252).

This patch should catch that situation before it happens and throw a real lisp error instead.