### PR TITLE
enable builds on macos

### DIFF
--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -5,6 +5,7 @@
 
 (define-foreign-library libglpk
   (:windows (:or "glpk" "glpk_4_65"))
+  (:darwin (:or "libglpk" "libglpk.dylib" "libglpk.40.dylib"))
   (:unix (:or "libglpk" "libglpk.so.40"))
   (t (:default "libglpk")))
 


### PR DESCRIPTION
I needed to add the following argument to `define-foreign-library` to get the system to successfully compile on macOS.